### PR TITLE
Add CLI-based HTML templater

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+*.pyo

--- a/README.md
+++ b/README.md
@@ -1,1 +1,48 @@
 # Webtemplater
+
+Prototype web service for uploading DOCX templates and generating documents per user.  
+The repository also contains a small Jinja2 based CLI tool for rendering static HTML from templates.
+
+## Setup
+
+1. Create virtual environment and install requirements:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Run the application:
+
+```bash
+python run.py
+```
+
+The application uses SQLite database `webtemplater.db` by default.
+
+## CLI Usage
+
+The `webtemplater` package provides a simple command line interface for
+rendering Jinja2 templates into HTML files.
+
+Render a template using a JSON context file:
+
+```bash
+python -m webtemplater.cli render templates/hello.html.j2 context.json output.html
+```
+
+The `--templates` option can be used to specify a custom templates directory.
+
+## Notes on Specification
+
+The provided UI specification references a library called `pydoctemplater`,
+which could not be found on PyPI. Instead, this project uses [`docxtpl`](https://github.com/elapouya/python-docx-template)
+for DOCX templating.
+
+This repository implements only basic functionality:
+
+- User registration and login with hashed passwords.
+- Uploading DOCX templates, stored per user.
+- Listing templates and generating a filled document from JSON context.
+
+The full specification includes many additional modules (RBAC, admin interface,
+integrations, etc.) which are out of scope for this initial prototype.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,29 @@
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+from flask_login import LoginManager
+from flask_wtf.csrf import CSRFProtect
+
+# Initialize extensions
+
+db = SQLAlchemy()
+login_manager = LoginManager()
+csrf = CSRFProtect()
+
+
+def create_app(config_object='config.Config'):
+    app = Flask(__name__)
+    app.config.from_object(config_object)
+
+    db.init_app(app)
+    login_manager.init_app(app)
+    csrf.init_app(app)
+
+    login_manager.login_view = 'auth.login'
+
+    with app.app_context():
+        from .views import auth, templates
+        app.register_blueprint(auth.bp)
+        app.register_blueprint(templates.bp)
+        db.create_all()
+
+    return app

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,0 +1,4 @@
+from .user import User
+from .template import Template
+
+__all__ = ['User', 'Template']

--- a/app/models/template.py
+++ b/app/models/template.py
@@ -1,0 +1,11 @@
+from datetime import datetime
+
+from .. import db
+
+
+class Template(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    filename = db.Column(db.String(255), nullable=False)
+    path = db.Column(db.String(255), nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    owner_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,0 +1,25 @@
+from datetime import datetime
+from werkzeug.security import generate_password_hash, check_password_hash
+from flask_login import UserMixin
+
+from .. import db, login_manager
+
+
+class User(UserMixin, db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    email = db.Column(db.String(120), unique=True, nullable=False)
+    password_hash = db.Column(db.String(128), nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    templates = db.relationship('Template', backref='owner', lazy=True)
+
+    def set_password(self, password):
+        self.password_hash = generate_password_hash(password)
+
+    def check_password(self, password):
+        return check_password_hash(self.password_hash, password)
+
+
+@login_manager.user_loader
+def load_user(user_id):
+    return User.query.get(int(user_id))

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>{{ title or 'Webtemplater' }}</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css">
+</head>
+<body class="p-3">
+<nav class="mb-3">
+    <a href="/templates/">Templates</a>
+    {% if current_user.is_authenticated %}
+        <a href="{{ url_for('auth.logout') }}">Logout</a>
+    {% else %}
+        <a href="{{ url_for('auth.login') }}">Login</a>
+    {% endif %}
+</nav>
+{% with messages = get_flashed_messages(with_categories=True) %}
+  {% if messages %}
+    {% for category, message in messages %}
+      <div class="alert alert-{{ category }}">{{ message }}</div>
+    {% endfor %}
+  {% endif %}
+{% endwith %}
+
+{% block content %}{% endblock %}
+</body>
+</html>

--- a/app/templates/fill_template.html
+++ b/app/templates/fill_template.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Fill Template: {{ template.filename }}</h2>
+<form method="post">
+    <div class="mb-3">
+        <label>Context (JSON)</label>
+        <textarea name="context" class="form-control" rows="5" required></textarea>
+    </div>
+    <button type="submit" class="btn btn-primary">Generate</button>
+</form>
+{% endblock %}

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -1,0 +1,20 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Login</h2>
+<form method="post">
+    <div class="mb-3">
+        <label>Email</label>
+        <input type="email" name="email" class="form-control" required>
+    </div>
+    <div class="mb-3">
+        <label>Password</label>
+        <input type="password" name="password" class="form-control" required>
+    </div>
+    <div class="mb-3 form-check">
+        <input type="checkbox" class="form-check-input" name="remember" id="remember">
+        <label class="form-check-label" for="remember">Remember me</label>
+    </div>
+    <button type="submit" class="btn btn-primary">Login</button>
+</form>
+<a href="{{ url_for('auth.signup') }}">Sign Up</a>
+{% endblock %}

--- a/app/templates/signup.html
+++ b/app/templates/signup.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Sign Up</h2>
+<form method="post">
+    <div class="mb-3">
+        <label>Email</label>
+        <input type="email" name="email" class="form-control" required>
+    </div>
+    <div class="mb-3">
+        <label>Password</label>
+        <input type="password" name="password" class="form-control" required>
+    </div>
+    <button type="submit" class="btn btn-primary">Create Account</button>
+</form>
+{% endblock %}

--- a/app/templates/template_list.html
+++ b/app/templates/template_list.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Your Templates</h2>
+<a href="{{ url_for('templates.upload_template') }}" class="btn btn-success mb-3">Upload Template</a>
+<table class="table">
+    <tr><th>Name</th><th>Uploaded</th><th></th></tr>
+    {% for t in templates %}
+    <tr>
+        <td>{{ t.filename }}</td>
+        <td>{{ t.created_at.strftime('%Y-%m-%d') }}</td>
+        <td><a href="{{ url_for('templates.fill_template', template_id=t.id) }}" class="btn btn-primary btn-sm">Fill</a></td>
+    </tr>
+    {% else %}
+    <tr><td colspan="3">No templates uploaded.</td></tr>
+    {% endfor %}
+</table>
+{% endblock %}

--- a/app/templates/upload_template.html
+++ b/app/templates/upload_template.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Upload Template</h2>
+<form method="post" enctype="multipart/form-data">
+    <div class="mb-3">
+        <input type="file" name="file" class="form-control" accept=".docx" required>
+    </div>
+    <button type="submit" class="btn btn-primary">Upload</button>
+</form>
+{% endblock %}

--- a/app/views/__init__.py
+++ b/app/views/__init__.py
@@ -1,0 +1,3 @@
+from . import auth, templates
+
+__all__ = ['auth', 'templates']

--- a/app/views/auth.py
+++ b/app/views/auth.py
@@ -1,0 +1,48 @@
+from flask import Blueprint, render_template, redirect, url_for, flash, request
+from flask_login import login_user, logout_user, login_required, current_user
+
+from .. import db
+from ..models import User
+
+bp = Blueprint('auth', __name__, url_prefix='/auth')
+
+
+@bp.route('/signup', methods=['GET', 'POST'])
+def signup():
+    if current_user.is_authenticated:
+        return redirect(url_for('templates.list_templates'))
+    if request.method == 'POST':
+        email = request.form['email']
+        password = request.form['password']
+        if User.query.filter_by(email=email).first():
+            flash('Email already registered.', 'danger')
+            return redirect(url_for('auth.signup'))
+        user = User(email=email)
+        user.set_password(password)
+        db.session.add(user)
+        db.session.commit()
+        login_user(user)
+        return redirect(url_for('templates.list_templates'))
+    return render_template('signup.html')
+
+
+@bp.route('/login', methods=['GET', 'POST'])
+def login():
+    if current_user.is_authenticated:
+        return redirect(url_for('templates.list_templates'))
+    if request.method == 'POST':
+        email = request.form['email']
+        password = request.form['password']
+        user = User.query.filter_by(email=email).first()
+        if user and user.check_password(password):
+            login_user(user, remember='remember' in request.form)
+            return redirect(url_for('templates.list_templates'))
+        flash('Invalid credentials', 'danger')
+    return render_template('login.html')
+
+
+@bp.route('/logout')
+@login_required
+def logout():
+    logout_user()
+    return redirect(url_for('auth.login'))

--- a/app/views/templates.py
+++ b/app/views/templates.py
@@ -1,0 +1,57 @@
+import os
+import json
+from flask import Blueprint, render_template, redirect, url_for, flash, request, send_file, current_app
+from flask_login import login_required, current_user
+from werkzeug.utils import secure_filename
+from docxtpl import DocxTemplate
+
+from .. import db
+from ..models import Template
+
+bp = Blueprint('templates', __name__, url_prefix='/templates')
+
+UPLOAD_FOLDER = 'user_templates'
+
+
+@bp.route('/')
+@login_required
+def list_templates():
+    templates = Template.query.filter_by(owner_id=current_user.id).all()
+    return render_template('template_list.html', templates=templates)
+
+
+@bp.route('/upload', methods=['GET', 'POST'])
+@login_required
+def upload_template():
+    if request.method == 'POST':
+        file = request.files['file']
+        if not file or file.filename == '':
+            flash('No file selected', 'danger')
+            return redirect(url_for('templates.upload_template'))
+        filename = secure_filename(file.filename)
+        os.makedirs(UPLOAD_FOLDER, exist_ok=True)
+        path = os.path.join(UPLOAD_FOLDER, filename)
+        file.save(path)
+        tmpl = Template(filename=filename, path=path, owner=current_user)
+        db.session.add(tmpl)
+        db.session.commit()
+        return redirect(url_for('templates.list_templates'))
+    return render_template('upload_template.html')
+
+
+@bp.route('/<int:template_id>/fill', methods=['GET', 'POST'])
+@login_required
+def fill_template(template_id):
+    tmpl = Template.query.filter_by(id=template_id, owner_id=current_user.id).first_or_404()
+    if request.method == 'POST':
+        try:
+            context = json.loads(request.form['context'])
+        except json.JSONDecodeError:
+            flash('Invalid JSON', 'danger')
+            return render_template('fill_template.html', template=tmpl)
+        doc = DocxTemplate(tmpl.path)
+        doc.render(context)
+        output_path = os.path.join(UPLOAD_FOLDER, f"filled_{tmpl.filename}")
+        doc.save(output_path)
+        return send_file(output_path, as_attachment=True)
+    return render_template('fill_template.html', template=tmpl)

--- a/config.py
+++ b/config.py
@@ -1,0 +1,6 @@
+import os
+
+class Config:
+    SECRET_KEY = os.environ.get('SECRET_KEY', 'changeme')
+    SQLALCHEMY_DATABASE_URI = 'sqlite:///webtemplater.db'
+    SQLALCHEMY_TRACK_MODIFICATIONS = False

--- a/context.json
+++ b/context.json
@@ -1,0 +1,5 @@
+{
+  "title": "Hello Example",
+  "heading": "Welcome",
+  "message": "This page was generated using webtemplater CLI."
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+Flask>=2.3
+Flask-SQLAlchemy>=3.0
+Flask-Login>=0.6
+Flask-WTF>=1.1
+Werkzeug>=2.3
+docxtpl>=0.20
+Jinja2>=3.1
+click>=8.1

--- a/run.py
+++ b/run.py
@@ -1,0 +1,6 @@
+from app import create_app
+
+app = create_app()
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/templates/hello.html.j2
+++ b/templates/hello.html.j2
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>{{ title }}</title>
+</head>
+<body>
+  <h1>{{ heading }}</h1>
+  <p>{{ message }}</p>
+</body>
+</html>

--- a/webtemplater/__init__.py
+++ b/webtemplater/__init__.py
@@ -1,0 +1,5 @@
+"""Simple Jinja2-based templating engine with CLI."""
+
+from .renderer import TemplateRenderer
+
+__all__ = ['TemplateRenderer']

--- a/webtemplater/cli.py
+++ b/webtemplater/cli.py
@@ -1,0 +1,35 @@
+"""Command line interface for rendering templates."""
+
+import json
+from pathlib import Path
+
+import click
+
+from .renderer import TemplateRenderer
+
+
+@click.group()
+@click.option('--templates', '-t', default='templates', show_default=True,
+              help='Directory with Jinja2 templates.')
+@click.pass_context
+def cli(ctx: click.Context, templates: str):
+    """Render HTML pages from templates."""
+    ctx.obj = TemplateRenderer(templates)
+
+
+@cli.command()
+@click.argument('template')
+@click.argument('context_file')
+@click.argument('output')
+@click.pass_obj
+def render(renderer: TemplateRenderer, template: str, context_file: str, output: str):
+    """Render TEMPLATE using data from CONTEXT_FILE into OUTPUT."""
+    with open(context_file, 'r', encoding='utf-8') as f:
+        context = json.load(f)
+    result = renderer.render(template, context)
+    Path(output).write_text(result, encoding='utf-8')
+    click.echo(f"Generated {output}")
+
+
+if __name__ == '__main__':
+    cli()

--- a/webtemplater/renderer.py
+++ b/webtemplater/renderer.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+from typing import Any, Mapping
+
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+
+class TemplateRenderer:
+    """Render Jinja2 templates from a directory."""
+
+    def __init__(self, template_dir: str | Path):
+        template_dir = Path(template_dir)
+        self.env = Environment(
+            loader=FileSystemLoader(template_dir),
+            autoescape=select_autoescape(['html', 'xml'])
+        )
+
+    def render(self, template_name: str, context: Mapping[str, Any]) -> str:
+        """Render a template with the given context and return the string."""
+        template = self.env.get_template(template_name)
+        return template.render(**context)


### PR DESCRIPTION
## Summary
- implement simple Jinja2 `TemplateRenderer`
- add CLI for rendering templates
- provide example template and context
- document CLI usage and update requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684033bef4f483248197ab085584988c